### PR TITLE
Updated lambda to python 3.9

### DIFF
--- a/recipes/net/hpc_large_scale/assets/main.yaml
+++ b/recipes/net/hpc_large_scale/assets/main.yaml
@@ -470,7 +470,7 @@ Resources:
     Properties:
       Description: GetAZLambdaFunction
       Timeout: 60
-      Runtime: python3.7
+      Runtime: python3.9
       Handler: index.handler
       Role: !GetAtt GetAZLambdaRole.Arn
       Code:


### PR DESCRIPTION
Simple change to update the version of Python used in the network Lambda stack. 

Looks like the planned deprecation has now happened in new accounts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
